### PR TITLE
chore: swap RMagick gem with rmagick

### DIFF
--- a/lib/dzt.rb
+++ b/lib/dzt.rb
@@ -1,3 +1,3 @@
-require 'RMagick'
+require 'rmagick'
 require 'dzt/version'
 require 'dzt/tiler'

--- a/spec/dzt/dzt_spec.rb
+++ b/spec/dzt/dzt_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'RMagick'
+require 'rmagick'
 include Magick
 
 describe DZT do

--- a/spec/dzt/tiler_spec.rb
+++ b/spec/dzt/tiler_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'RMagick'
+require 'rmagick'
 include Magick
 
 describe DZT::Tiler do


### PR DESCRIPTION
This PR replicates a fork that had previously been hosted at `dblandin/dzt`, which resolves dependency incompatibilities by swapping out `RMagick` with `rmagick`. That repo was recently removed but we should be hosting it under the artsy org anyways. This PR does that. A follow up PR will be made to gemini to use this fork