### PR TITLE
chore: pin rmagick to <~ 5.0.0

### DIFF
--- a/dzt.gemspec
+++ b/dzt.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Tile images for deep-zoom.'
   s.add_dependency 'gli'
-  s.add_dependency 'rmagick'
+  s.add_dependency 'rmagick', '~> 5.0.0'
 end


### PR DESCRIPTION
This PR pins `rmagick` to `<~ 5.0.0` to limit the number of changes being made to `gemini` while bumping the `pg` version. See related [PR](https://github.com/artsy/gemini/pull/620).